### PR TITLE
Fix pod version conflicts

### DIFF
--- a/react-native-pure-jwt.podspec
+++ b/react-native-pure-jwt.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'JWT', '3.0.0-beta.11'
+  s.dependency 'JWT', '~> 3.0.0-beta.11'
 end
 


### PR DESCRIPTION
Problem: Conflict with other pods that use JWT pod as dependency - including react-native-code-push. 

Solution: Using the `~>` operator in the pod dependency works like the ^ operator in npm - sets a floor rather than an exact requirement, allowing for more compatibility. 

No API change. 