### PR TITLE
fix pod version conflict

### DIFF
--- a/react-native-pure-jwt.podspec
+++ b/react-native-pure-jwt.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'JWT', '3.0.0-beta.12'
+  s.dependency 'JWT', '~> 3.0.0-beta.12'
 end
 


### PR DESCRIPTION
This package cannot be installed together with CodePush due to a version conflict of JWT.

(Was already fixed by #22 and then broken again by d1d7c352104a8d730a70334b6e34551726bb682f)

```
[!] CocoaPods could not find compatible versions for pod "JWT":
  In snapshot (Podfile.lock):
    JWT (= 3.0.0-beta.14, ~> 3.0.0-beta.12)

  In Podfile:
    CodePush (from `../node_modules/react-native-code-push`) was resolved to 7.0.2, which depends on
      JWT (~> 3.0.0-beta.12)

    react-native-pure-jwt (from `../node_modules/react-native-pure-jwt`) was resolved to 3.0.0, which depends on
      JWT (= 3.0.0-beta.12)


You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * changed the constraints of dependency `JWT` inside your development pod `react-native-pure-jwt`.
   You should run `pod update JWT` to apply changes you've made.
```