### PR TITLE
updating to react native 0.69.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
@@ -27,6 +28,7 @@ android {
 }
 
 repositories {
+    google()
     mavenCentral()
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,19 +5,19 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath("com.android.tools.build:gradle:7.1.1")
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 31
+    buildToolsVersion "31.0.0"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion 21
+        targetSdkVersion 31
         versionCode 3
         versionName "2.0.1"
     }


### PR DESCRIPTION
Hi,


I got an issue building my android app on a buildserver using the docker image https://hub.docker.com/r/reactnativecommunity/react-native-android
on a gitlab server.

buildserver throw an error:

ERROR:/root/.gradle/caches/transforms-3/50cfa3b0ad711666dcd57caf9637d52b/transformed/core-1.7.0/res/values/values.xml:105:5-114:25: AAPT: error: resource android:attr/lStar not found.

this happend after upgrading build.gradle file via the react native upgrade helper

https://react-native-community.github.io/upgrade-helper/?from=0.67.4&to=0.69.4

When I tried to build the app locally I added the correct ndk/sdk for the build to succeed.

But I am not able to do this with the reactnativecommunity/react-native-android docker image in CI

So hereby an open question to update the build.gradle file for the latest react native version.

I am not an android expert so open for other suggestions.

