### PR TITLE
Ability to set custom token headers

### DIFF
--- a/android/src/main/java/com/zaguiini/RNPureJwt/RNPureJwtModule.java
+++ b/android/src/main/java/com/zaguiini/RNPureJwt/RNPureJwtModule.java
@@ -145,10 +145,11 @@ public class RNPureJwtModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void sign(ReadableMap claims, String secret, ReadableMap options, Promise callback) {
         String algorithm = options.hasKey("alg") ? options.getString("alg") : "HS256";
+        Map<String, Object> optionsMap = options.toHashMap();
         JwtBuilder constructedToken = Jwts.builder()
                 .signWith(SignatureAlgorithm.forName(algorithm), this.toBase64(secret))
-                .setHeaderParam("alg", algorithm)
-                .setHeaderParam("typ", "JWT");
+                .setHeaderParam("typ", "JWT")
+                .setHeaderParams(optionsMap);
 
         Set<Map.Entry<String, Object>> entries = claims.toHashMap().entrySet();
 

--- a/ios/RNPureJwt.m
+++ b/ios/RNPureJwt.m
@@ -50,7 +50,7 @@ RCT_REMAP_METHOD(sign,
     
     NSString *algorithmName = options[@"alg"] ? options[@"alg"] : @"HS256";
     id holder = [JWTAlgorithmHSFamilyDataHolder new].algorithmName(algorithmName).secret(secret);
-    JWTCodingResultType *result = builder.claimsSet(claimsSet).addHolder(holder).result;
+    JWTCodingResultType *result = builder.claimsSet(claimsSet).headers(options).addHolder(holder).result;
     
     if(result.successResult) {
         resolve(result.successResult.encoded);

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -3,7 +3,11 @@ export interface DecodeResponse {
   payload: object
 }
 
-export interface SignOptions {
+interface CustomHeaders {
+  [key: string]: string | number | boolean
+}
+
+export interface SignOptions extends CustomHeaders {
   alg: 'HS256' | 'HS384' | 'HS512'
 }
 


### PR DESCRIPTION
There are some service providers like `zendesk` require you to set custom headers like `kid`. This is not possible with the current version. This PR solves that problem. Both the underlying ios and android libraries support the same. This PR is using the methods provided the native libraries.