### PR TITLE
fix: fixed deprecated issue by replacing jcenter() with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
…) in the buildscript repositories section

The jcenter() repository has been deprecated and is no longer available in newer Gradle versions.